### PR TITLE
Remove obsolete api-key options

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,11 @@ const { text } = await generateText({
 
 ### Configuration
 
-`createSapAiCore` accepts configuration options such as `baseURL`, `apiKey`, and custom headers:
+`createSapAiCore` accepts configuration options such as `baseURL` and custom headers:
 
 ```ts
 createSapAiCore({
   baseURL: 'https://your-sap-aicore-instance',
-  apiKey: 'your-api-key',
   headers: {
     'Custom-Header': 'value'
   }
@@ -45,7 +44,6 @@ Use `tokenProvider` to automatically fetch an access token before each request:
 ```ts
 createSapAiCore({
   baseURL: 'https://your-sap-aicore-instance',
-  apiKey: 'your-api-key',
   tokenProvider: {
     baseURL: 'https://auth.example.com/token',
     clientId: 'your-client-id',

--- a/src/sap-aicore-provider.test.ts
+++ b/src/sap-aicore-provider.test.ts
@@ -53,8 +53,7 @@ describe('chat', () => {
 
     it('should set the correct default api version', async () => {
       const provider = createSapAiCore({
-        baseURL: BASE_URL,
-        apiKey: 'test-api-key'
+        baseURL: BASE_URL
       });
 
       await provider('test-deployment').doGenerate({
@@ -69,7 +68,6 @@ describe('chat', () => {
     it('should pass headers', async () => {
       const provider = createSapAiCore({
         baseURL: BASE_URL,
-        apiKey: 'test-api-key',
         headers: {
           'Custom-Provider-Header': 'provider-header-value'
         }
@@ -85,7 +83,6 @@ describe('chat', () => {
       });
 
       expect(server.calls[0]!.requestHeaders).toStrictEqual({
-        'api-key': 'test-api-key',
         'content-type': 'application/json',
         'custom-provider-header': 'provider-header-value',
         'custom-request-header': 'request-header-value'
@@ -94,8 +91,7 @@ describe('chat', () => {
 
     it('should use the baseURL correctly', async () => {
       const provider = createSapAiCore({
-        baseURL: BASE_URL,
-        apiKey: 'test-api-key'
+        baseURL: BASE_URL
       });
 
       await provider('test-deployment').doGenerate({
@@ -111,7 +107,6 @@ describe('chat', () => {
       prepareTokenResponse('token123');
       const provider = createSapAiCore({
         baseURL: BASE_URL,
-        apiKey: 'test-api-key',
         tokenProvider: {
           baseURL: TOKEN_URL,
           clientId: 'id',
@@ -132,7 +127,6 @@ describe('chat', () => {
       prepareTokenResponse('token123');
       const provider = createSapAiCore({
         baseURL: BASE_URL,
-        apiKey: 'test-api-key',
         tokenProvider: {
           baseURL: TOKEN_URL,
           clientId: 'id',
@@ -162,8 +156,7 @@ describe('chat', () => {
       process.env.TOKEN_PROVIDER_CLIENT_SECRET = 'secret';
 
       const provider = createSapAiCore({
-        baseURL: BASE_URL,
-        apiKey: 'test-api-key'
+        baseURL: BASE_URL
       });
 
       await provider('test-deployment').doGenerate({

--- a/src/sap-aicore-provider.ts
+++ b/src/sap-aicore-provider.ts
@@ -1,6 +1,6 @@
 import { OpenAICompatibleChatLanguageModel, type OpenAICompatibleChatSettings } from '@ai-sdk/openai-compatible';
 import type { LanguageModelV1 } from '@ai-sdk/provider';
-import { type FetchFunction, loadApiKey, loadSetting } from '@ai-sdk/provider-utils';
+import { type FetchFunction, loadSetting } from '@ai-sdk/provider-utils';
 import { createFetchWithToken, type TokenProviderConfig } from './lib/fetch-with-token-provider';
 import { loadObjectSetting } from './lib/load-object-setting';
 
@@ -13,7 +13,6 @@ export interface SapAiCoreProvider {
 
 export interface SapAiCoreProviderSettings {
   baseURL?: string;
-  apiKey?: string;
   headers?: Record<string, string>;
   fetch?: FetchFunction;
   apiVersion?: string;
@@ -22,11 +21,6 @@ export interface SapAiCoreProviderSettings {
 
 export function createSapAiCore(options: SapAiCoreProviderSettings = {}): SapAiCoreProvider {
   const getHeaders = () => ({
-    'api-key': loadApiKey({
-      apiKey: options.apiKey,
-      environmentVariableName: 'AZURE_API_KEY',
-      description: 'SAP AI Core API Key'
-    }),
     ...options.headers
   });
 


### PR DESCRIPTION
## Summary
- drop `apiKey` option from provider
- update tests and README for new configuration

## Testing
- `npm run ci:check`

------
https://chatgpt.com/codex/tasks/task_e_684bd50f738c832999fddc91381b0d72