### PR TITLE
Handle unauthorized token fetch

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,4 +2,3 @@ export type { SapAiCoreModelId, SapAiCoreProvider, SapAiCoreProviderSettings } f
 export { createSapAiCore, sapAiCore } from './sap-aicore-provider';
 export type { TokenProviderConfig } from './lib/fetch-with-token-provider';
 export { createFetchWithToken } from './lib/fetch-with-token-provider';
-export { loadObjectSetting } from './lib/load-object-setting';

--- a/src/lib/fetch-with-token-provider.test.ts
+++ b/src/lib/fetch-with-token-provider.test.ts
@@ -63,4 +63,18 @@ describe('createFetchWithToken', () => {
 
     expect(server.calls[1]!.requestHeaders['x-token']).toBe('Bearer token123');
   });
+
+  it('throws when token request is unauthorized', async () => {
+    server.urls[ACCESS_TOKEN_URL].response = {
+      type: 'error',
+      status: 401
+    };
+    const fetch = createFetchWithToken({
+      accessTokenBaseUrl: ACCESS_TOKEN_BASE_URL,
+      clientId: 'id',
+      clientSecret: 'secret'
+    });
+
+    await expect(fetch(API_URL)).rejects.toThrow('Unauthorized');
+  });
 });

--- a/src/lib/fetch-with-token-provider.ts
+++ b/src/lib/fetch-with-token-provider.ts
@@ -43,7 +43,7 @@ export function createFetchWithToken(config?: TokenProviderConfig, baseFetch: Fe
         headers: { Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}` }
       });
       if (!tokenResponse.ok) {
-        throw new Error('Unauthorized');
+        throw new Error(`Token fetch failed: ${tokenResponse.status} ${tokenResponse.statusText}`);
       }
       const response = (await tokenResponse.json()) as { access_token: string };
       access_token = response.access_token;

--- a/src/lib/fetch-with-token-provider.ts
+++ b/src/lib/fetch-with-token-provider.ts
@@ -38,11 +38,14 @@ export function createFetchWithToken(config?: TokenProviderConfig, baseFetch: Fe
     const now = Date.now();
     if (!access_token || now > expiresAt) {
       const accessTokenUrl = `${accessTokenBaseUrl}/oauth/token?grant_type=client_credentials`;
-      const tokenResponce = await baseFetch(accessTokenUrl, {
+      const tokenResponse = await baseFetch(accessTokenUrl, {
         method: 'GET',
         headers: { Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}` }
       });
-      const response = (await tokenResponce.json()) as { access_token: string };
+      if (!tokenResponse.ok) {
+        throw new Error('Unauthorized');
+      }
+      const response = (await tokenResponse.json()) as { access_token: string };
       access_token = response.access_token;
       expiresAt = now + ttl;
     }


### PR DESCRIPTION
## Summary
- throw error when token endpoint returns non-ok response
- test unauthorized token scenario
- fix build by dropping unused export

## Testing
- `npm run ci:check`

------
https://chatgpt.com/codex/tasks/task_e_684bfe45f3808329b63717c7658b5867